### PR TITLE
hotfix: 잔디 공부시간 저장 로직 변경

### DIFF
--- a/src/main/java/develop/grassserver/grass/domain/entity/Grass.java
+++ b/src/main/java/develop/grassserver/grass/domain/entity/Grass.java
@@ -42,9 +42,9 @@ public class Grass extends BaseEntity {
     private Member member;
 
     public void updateStudyTime(Duration todayStudyTime) {
-        Duration plusTime = todayStudyTime.minus(studyTime);
-        member.getStudyRecord().updateTotalStudyTime(plusTime);
-        this.studyTime = todayStudyTime;
+        member.getStudyRecord().updateTotalStudyTime(todayStudyTime);
+        this.studyTime = todayStudyTime.plus(studyTime);
+        
     }
 
     public void updateGrassScore(int grassScore) {


### PR DESCRIPTION
## 💡 Issue number (ex. #1000)

## 🚀 Description
잔디 공부시간 저장 로직 변경
- 기존엔  (request 공부시간 - 이전 공부시간)을 계산해서 totalStudyTime에 공부 시간 차이를 업데이트함
- request 공부시간을 바로 totalStudyTime 공부시간 업데이트로 사용하는 것으로 바꿈
## 💻 etc.
