### PR TITLE
[Feature] 프리즈 사용 기능 구현

### DIFF
--- a/src/main/java/develop/grassserver/profile/application/exception/NotEnoughFreezeCountException.java
+++ b/src/main/java/develop/grassserver/profile/application/exception/NotEnoughFreezeCountException.java
@@ -1,0 +1,21 @@
+package develop.grassserver.profile.application.exception;
+
+import develop.grassserver.common.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+
+public class NotEnoughFreezeCountException extends RuntimeException {
+
+    private static final String MESSAGE = "프리즈 개수가 부족합니다.";
+
+    public NotEnoughFreezeCountException() {
+        super(MESSAGE);
+    }
+
+    public ApiUtils.ApiResult<?> body() {
+        return ApiUtils.error(HttpStatus.BAD_REQUEST, getMessage());
+    }
+
+    public HttpStatus status() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/develop/grassserver/profile/application/service/FreezeService.java
+++ b/src/main/java/develop/grassserver/profile/application/service/FreezeService.java
@@ -59,4 +59,12 @@ public class FreezeService {
             throw new NotEnoughGrassScoreException();
         }
     }
+
+    @Transactional
+    public void useFreeze(Member member) {
+        Member findMember = memberRepository.findByIdWithProfile(member.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        findMember.getProfile().getFreeze().decrease();
+    }
 }

--- a/src/main/java/develop/grassserver/profile/application/service/FreezeService.java
+++ b/src/main/java/develop/grassserver/profile/application/service/FreezeService.java
@@ -1,5 +1,6 @@
 package develop.grassserver.profile.application.service;
 
+import develop.grassserver.grass.application.service.MemberGrassService;
 import develop.grassserver.grass.domain.entity.GrassScoreAggregate;
 import develop.grassserver.grass.infrastructure.repositiory.GrassScoreAggregateRepository;
 import develop.grassserver.member.domain.entity.Member;
@@ -25,6 +26,7 @@ public class FreezeService {
     private final MemberRepository memberRepository;
     private final ProfileRepository profileRepository;
     private final GrassScoreAggregateRepository grassScoreAggregateRepository;
+    private final MemberGrassService memberGrassService;
 
     public FreezeCountResponse getFreezeCount(Member member) {
         Member findMember = memberRepository.findByIdWithProfile(member.getId())
@@ -66,5 +68,6 @@ public class FreezeService {
                 .orElseThrow(EntityNotFoundException::new);
 
         findMember.getProfile().getFreeze().decrease();
+        memberGrassService.createAttendance(member);
     }
 }

--- a/src/main/java/develop/grassserver/profile/domain/entity/Freeze.java
+++ b/src/main/java/develop/grassserver/profile/domain/entity/Freeze.java
@@ -1,5 +1,6 @@
 package develop.grassserver.profile.domain.entity;
 
+import develop.grassserver.profile.application.exception.NotEnoughFreezeCountException;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
@@ -7,9 +8,16 @@ import lombok.Getter;
 @Embeddable
 public class Freeze {
 
+    private int freezeCount;
+
     public Freeze() {
         this.freezeCount = 0;
     }
 
-    private int freezeCount;
+    public void decrease() {
+        if (this.freezeCount > 0) {
+            this.freezeCount--;
+        }
+        throw new NotEnoughFreezeCountException();
+    }
 }

--- a/src/main/java/develop/grassserver/profile/domain/entity/Freeze.java
+++ b/src/main/java/develop/grassserver/profile/domain/entity/Freeze.java
@@ -15,9 +15,9 @@ public class Freeze {
     }
 
     public void decrease() {
-        if (this.freezeCount > 0) {
-            this.freezeCount--;
+        if (this.freezeCount <= 0) {
+            throw new NotEnoughFreezeCountException();
         }
-        throw new NotEnoughFreezeCountException();
+        this.freezeCount--;
     }
 }

--- a/src/main/java/develop/grassserver/profile/presentation/controller/FreezeController.java
+++ b/src/main/java/develop/grassserver/profile/presentation/controller/FreezeController.java
@@ -9,6 +9,7 @@ import develop.grassserver.profile.presentation.dto.FreezeCountResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +31,13 @@ public class FreezeController {
     @PostMapping
     public ResponseEntity<ApiResult<String>> exchangeFreeze(@LoginMember Member member) {
         freezeService.exchangeFreeze(member);
+        return ResponseEntity.ok()
+                .body(ApiUtils.success());
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResult<String>> useFreeze(@LoginMember Member member) {
+        freezeService.useFreeze(member);
         return ResponseEntity.ok()
                 .body(ApiUtils.success());
     }

--- a/src/main/java/develop/grassserver/profile/presentation/exception/ProfileExceptionHandler.java
+++ b/src/main/java/develop/grassserver/profile/presentation/exception/ProfileExceptionHandler.java
@@ -2,6 +2,7 @@ package develop.grassserver.profile.presentation.exception;
 
 import develop.grassserver.common.utils.ApiUtils.ApiResult;
 import develop.grassserver.profile.application.exception.ImageUploadFailedException;
+import develop.grassserver.profile.application.exception.NotEnoughFreezeCountException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +12,11 @@ public class ProfileExceptionHandler {
 
     @ExceptionHandler(ImageUploadFailedException.class)
     public ResponseEntity<ApiResult<?>> imageUploadFailedException(ImageUploadFailedException exception) {
+        return new ResponseEntity<>(exception.body(), exception.status());
+    }
+
+    @ExceptionHandler(NotEnoughFreezeCountException.class)
+    public ResponseEntity<ApiResult<?>> notEnoughFreezeCountException(ImageUploadFailedException exception) {
         return new ResponseEntity<>(exception.body(), exception.status());
     }
 }


### PR DESCRIPTION
## 💡 Issue number (ex. #1000)
close: #179 
## 🚀 Description
프리즈 사용 기능 구현
## 💻 etc.
1. 프리즈 개수 관련 custom exception을 도메인에서 던지는데, exception 클래스 위치는 application으로 넣어뒀습니다. domain exception 폴더를 따로 만들어서 구분하는 게 맞을지 고민이 됩니다.
2. 출석 함수 호출 시 쿼리가 많이 날라갑니다. 이 부분은 차차 성능 개선을 해보겠습니다. 그러니 프리즈 사용 로직 쿼리랑 출석 쿼리를 분리해서 봐주셨으면 합니다.. 프리즈 사용 로직 자체에서는 쿼리가 2개밖에 안 날라갑니다!